### PR TITLE
Ensure consistency of 'train' argument between data generator functions

### DIFF
--- a/DINCAE/__init__.py
+++ b/DINCAE/__init__.py
@@ -124,7 +124,7 @@ def data_generator(lon,lat,time,data_full,missing,
                    jitter_std = 0.05):
 
     return data_generator_list(lon,lat,time,[data_full],[missing],
-                   train = True,
+                   train = train,
                    ntime_win = ntime_win,
                    obs_err_std = [obs_err_std],
                    jitter_std = [jitter_std])


### PR DESCRIPTION
Fixed a bug where the 'train' argument was not being consistently passed from the 'data_generator' function to the 'data_generator_list' function. This inconsistency was causing the 'train' value to unexpectedly switch to 'True' during data generation for the testing part. 
The 'train' argument is now directly passed from 'data_generator' to 'data_generator_list', ensuring its value remains consistent throughout the data generation process.